### PR TITLE
Fix #29: In the string edit page, display the base string with translated commands.

### DIFF
--- a/scripts/filter_update_langs
+++ b/scripts/filter_update_langs
@@ -103,6 +103,8 @@ if not os.path.isdir(outputdir):
 # Read input language definitions
 inputlangs = {}
 for f in os.listdir(inputdir):
+    if f in {"CMakeLists.txt"}:
+        continue
     n = os.path.join(inputdir, f)
     if not os.path.isfile(n):
         continue

--- a/webtranslate/utils.py
+++ b/webtranslate/utils.py
@@ -193,7 +193,7 @@ def create_displayed_base_text(pdata, text):
     blng = pdata.get_base_language()
     if blng is None:
         return text
-    str_info = language_file.check_string(pdata.projtype, text, True, None, blng, True)
+    str_info = language_file.check_string(pdata.projtype, text, True, None, blng, True, save_pieces=True)
     if str_info.has_error or str_info.pieces is None:
         return text
     return str_info.get_translation_text()


### PR DESCRIPTION
fc2f4273cc originally implemented #29 as a feature, except it forgot to set the parameter to enable it...