### PR TITLE
Fix #36: translated texts should be displayed and edited according to their ltr/rtl text direction.

### DIFF
--- a/scripts/filter_update_langs
+++ b/scripts/filter_update_langs
@@ -8,7 +8,7 @@ import os.path
 
 
 # Keywords to use from OpenTTD langfiles
-filterkeywords = ["##name", "##ownname", "##isocode", "##plural", "##grflangid", "##gender", "##case"]
+filterkeywords = ["##name", "##ownname", "##isocode", "##plural", "##textdir", "##grflangid", "##gender", "##case"]
 
 
 def filter_langfile(filename):

--- a/stable_languages/afrikaans.txt
+++ b/stable_languages/afrikaans.txt
@@ -2,5 +2,6 @@
 ##ownname Afrikaans
 ##isocode af_ZA
 ##plural 0
+##textdir ltr
 ##grflangid 0x1b
 ##gender male

--- a/stable_languages/arabic_egypt.txt
+++ b/stable_languages/arabic_egypt.txt
@@ -2,4 +2,5 @@
 ##ownname Arabic (Egypt)
 ##isocode ar_EG
 ##plural 1
+##textdir rtl
 ##grflangid 0x14

--- a/stable_languages/basque.txt
+++ b/stable_languages/basque.txt
@@ -2,4 +2,5 @@
 ##ownname Euskara
 ##isocode eu_ES
 ##plural 0
+##textdir ltr
 ##grflangid 0x21

--- a/stable_languages/belarusian.txt
+++ b/stable_languages/belarusian.txt
@@ -2,6 +2,7 @@
 ##ownname Беларуская
 ##isocode be_BY
 ##plural 6
+##textdir ltr
 ##grflangid 0x10
 ##gender m f n p
 ##case m f n p nom gen dat acc abl pre

--- a/stable_languages/brazilian_portuguese.txt
+++ b/stable_languages/brazilian_portuguese.txt
@@ -2,5 +2,6 @@
 ##ownname Português (BR)
 ##isocode pt_BR
 ##plural 2
+##textdir ltr
 ##grflangid 0x37
 ##gender m f

--- a/stable_languages/bulgarian.txt
+++ b/stable_languages/bulgarian.txt
@@ -2,6 +2,7 @@
 ##ownname Български
 ##isocode bg_BG
 ##plural 0
+##textdir ltr
 ##grflangid 0x18
 ##gender m f n p
 ##case m f n p

--- a/stable_languages/catalan.txt
+++ b/stable_languages/catalan.txt
@@ -2,5 +2,6 @@
 ##ownname Català
 ##isocode ca_ES
 ##plural 0
+##textdir ltr
 ##grflangid 0x22
 ##gender Masculin Femenin

--- a/stable_languages/croatian.txt
+++ b/stable_languages/croatian.txt
@@ -2,6 +2,7 @@
 ##ownname Hrvatski
 ##isocode hr_HR
 ##plural 6
+##textdir ltr
 ##grflangid 0x38
 ##gender male female middle
 ##case nom gen dat aku vok lok ins

--- a/stable_languages/czech.txt
+++ b/stable_languages/czech.txt
@@ -2,6 +2,7 @@
 ##ownname Čeština
 ##isocode cs_CZ
 ##plural 10
+##textdir ltr
 ##grflangid 0x15
 ##gender m f n map mnp fp np
 ##case nom gen dat acc voc loc ins big small

--- a/stable_languages/danish.txt
+++ b/stable_languages/danish.txt
@@ -2,4 +2,5 @@
 ##ownname Dansk
 ##isocode da_DK
 ##plural 0
+##textdir ltr
 ##grflangid 0x2d

--- a/stable_languages/dutch.txt
+++ b/stable_languages/dutch.txt
@@ -2,4 +2,5 @@
 ##ownname Nederlands
 ##isocode nl_NL
 ##plural 0
+##textdir ltr
 ##grflangid 0x1f

--- a/stable_languages/english.txt
+++ b/stable_languages/english.txt
@@ -2,4 +2,5 @@
 ##ownname English (UK)
 ##isocode en_GB
 ##plural 0
+##textdir ltr
 ##grflangid 0x01

--- a/stable_languages/english_AU.txt
+++ b/stable_languages/english_AU.txt
@@ -2,4 +2,5 @@
 ##ownname English (AU)
 ##isocode en_AU
 ##plural 0
+##textdir ltr
 ##grflangid 0x3d

--- a/stable_languages/english_US.txt
+++ b/stable_languages/english_US.txt
@@ -2,4 +2,5 @@
 ##ownname English (US)
 ##isocode en_US
 ##plural 0
+##textdir ltr
 ##grflangid 0x00

--- a/stable_languages/esperanto.txt
+++ b/stable_languages/esperanto.txt
@@ -2,5 +2,6 @@
 ##ownname Esperanto
 ##isocode eo_EO
 ##plural 0
+##textdir ltr
 ##grflangid 0x05
 ##case n

--- a/stable_languages/estonian.txt
+++ b/stable_languages/estonian.txt
@@ -2,5 +2,6 @@
 ##ownname Eesti keel
 ##isocode et_EE
 ##plural 0
+##textdir ltr
 ##grflangid 0x34
 ##case g in sü

--- a/stable_languages/faroese.txt
+++ b/stable_languages/faroese.txt
@@ -2,5 +2,6 @@
 ##ownname Føroyskt
 ##isocode fo_FO
 ##plural 0
+##textdir ltr
 ##grflangid 0x12
 ##gender m f n

--- a/stable_languages/finnish.txt
+++ b/stable_languages/finnish.txt
@@ -2,4 +2,5 @@
 ##ownname Suomi
 ##isocode fi_FI
 ##plural 0
+##textdir ltr
 ##grflangid 0x35

--- a/stable_languages/french.txt
+++ b/stable_languages/french.txt
@@ -2,5 +2,6 @@
 ##ownname Français
 ##isocode fr_FR
 ##plural 2
+##textdir ltr
 ##grflangid 0x03
 ##gender m m2 f

--- a/stable_languages/gaelic.txt
+++ b/stable_languages/gaelic.txt
@@ -2,6 +2,7 @@
 ##ownname Gàidhlig
 ##isocode gd_GB
 ##plural 13
+##textdir ltr
 ##grflangid 0x13
 ##gender m f
 ##case nom gen dat voc

--- a/stable_languages/galician.txt
+++ b/stable_languages/galician.txt
@@ -2,5 +2,6 @@
 ##ownname Galego
 ##isocode gl_ES
 ##plural 0
+##textdir ltr
 ##grflangid 0x31
 ##gender m f n

--- a/stable_languages/german.txt
+++ b/stable_languages/german.txt
@@ -2,5 +2,6 @@
 ##ownname Deutsch
 ##isocode de_DE
 ##plural 0
+##textdir ltr
 ##grflangid 0x02
 ##gender m w n p

--- a/stable_languages/greek.txt
+++ b/stable_languages/greek.txt
@@ -2,6 +2,7 @@
 ##ownname Ελληνικά
 ##isocode el_GR
 ##plural 2
+##textdir ltr
 ##grflangid 0x1e
 ##gender m f n
 ##case subs date geniki

--- a/stable_languages/hebrew.txt
+++ b/stable_languages/hebrew.txt
@@ -2,6 +2,7 @@
 ##ownname עברית
 ##isocode he_IL
 ##plural 0
+##textdir rtl
 ##grflangid 0x61
 ##gender m f
 ##case singular plural gen

--- a/stable_languages/hungarian.txt
+++ b/stable_languages/hungarian.txt
@@ -2,5 +2,6 @@
 ##ownname Magyar
 ##isocode hu_HU
 ##plural 2
+##textdir ltr
 ##grflangid 0x24
 ##case t ba

--- a/stable_languages/icelandic.txt
+++ b/stable_languages/icelandic.txt
@@ -2,5 +2,6 @@
 ##ownname Íslenska
 ##isocode is_IS
 ##plural 0
+##textdir ltr
 ##grflangid 0x29
 ##gender karlkyn kvenkyn hvorugkyn

--- a/stable_languages/indonesian.txt
+++ b/stable_languages/indonesian.txt
@@ -2,4 +2,5 @@
 ##ownname Bahasa Indonesia
 ##isocode id_ID
 ##plural 1
+##textdir ltr
 ##grflangid 0x5a

--- a/stable_languages/irish.txt
+++ b/stable_languages/irish.txt
@@ -2,4 +2,5 @@
 ##ownname Gaeilge
 ##isocode ga_IE
 ##plural 4
+##textdir ltr
 ##grflangid 0x08

--- a/stable_languages/italian.txt
+++ b/stable_languages/italian.txt
@@ -2,6 +2,7 @@
 ##ownname Italiano
 ##isocode it_IT
 ##plural 0
+##textdir ltr
 ##grflangid 0x27
 ##gender m ma f
 ##case ms mp fs fp

--- a/stable_languages/japanese.txt
+++ b/stable_languages/japanese.txt
@@ -2,4 +2,5 @@
 ##ownname 日本語
 ##isocode ja_JP
 ##plural 1
+##textdir ltr
 ##grflangid 0x39

--- a/stable_languages/korean.txt
+++ b/stable_languages/korean.txt
@@ -2,5 +2,6 @@
 ##ownname 한국어
 ##isocode ko_KR
 ##plural 11
+##textdir ltr
 ##grflangid 0x3a
 ##gender m f

--- a/stable_languages/latin.txt
+++ b/stable_languages/latin.txt
@@ -2,6 +2,7 @@
 ##ownname Latina
 ##isocode la_VA
 ##plural 0
+##textdir ltr
 ##grflangid 0x66
 ##gender m f n mp fp np
 ##case gen acc abl dat

--- a/stable_languages/latvian.txt
+++ b/stable_languages/latvian.txt
@@ -2,6 +2,7 @@
 ##ownname Latviešu
 ##isocode lv_LV
 ##plural 3
+##textdir ltr
 ##grflangid 0x2a
 ##gender m f
 ##case kas

--- a/stable_languages/lithuanian.txt
+++ b/stable_languages/lithuanian.txt
@@ -2,6 +2,7 @@
 ##ownname Lietuvių
 ##isocode lt_LT
 ##plural 5
+##textdir ltr
 ##grflangid 0x2b
 ##gender vyr mot
 ##case kas ko kam ka kuo kur kreip

--- a/stable_languages/luxembourgish.txt
+++ b/stable_languages/luxembourgish.txt
@@ -2,4 +2,5 @@
 ##ownname Lëtzebuergesch
 ##isocode lb_LU
 ##plural 0
+##textdir ltr
 ##grflangid 0x23

--- a/stable_languages/malay.txt
+++ b/stable_languages/malay.txt
@@ -2,4 +2,5 @@
 ##ownname Melayu
 ##isocode ms_MY
 ##plural 0
+##textdir ltr
 ##grflangid 0x3c

--- a/stable_languages/norwegian_bokmal.txt
+++ b/stable_languages/norwegian_bokmal.txt
@@ -2,6 +2,7 @@
 ##ownname Norsk (bokmål)
 ##isocode nb_NO
 ##plural 0
+##textdir ltr
 ##grflangid 0x2f
 ##gender masculine feminine neuter
 ##case small

--- a/stable_languages/norwegian_nynorsk.txt
+++ b/stable_languages/norwegian_nynorsk.txt
@@ -2,6 +2,7 @@
 ##ownname Norsk (nynorsk)
 ##isocode nn_NO
 ##plural 0
+##textdir ltr
 ##grflangid 0x0e
 ##gender masculine feminine neuter
 ##case small

--- a/stable_languages/polish.txt
+++ b/stable_languages/polish.txt
@@ -2,6 +2,7 @@
 ##ownname Polski
 ##isocode pl_PL
 ##plural 7
+##textdir ltr
 ##grflangid 0x30
 ##gender m f n
 ##case d c b n m w

--- a/stable_languages/portuguese.txt
+++ b/stable_languages/portuguese.txt
@@ -2,5 +2,6 @@
 ##ownname Português
 ##isocode pt_PT
 ##plural 0
+##textdir ltr
 ##grflangid 0x36
 ##gender n m f mp fp

--- a/stable_languages/romanian.txt
+++ b/stable_languages/romanian.txt
@@ -2,4 +2,5 @@
 ##ownname Românӑ
 ##isocode ro_RO
 ##plural 0
+##textdir ltr
 ##grflangid 0x28

--- a/stable_languages/russian.txt
+++ b/stable_languages/russian.txt
@@ -2,6 +2,7 @@
 ##ownname Русский
 ##isocode ru_RU
 ##plural 6
+##textdir ltr
 ##grflangid 0x07
 ##gender m f n p
 ##case m f n p nom gen dat acc abl pre

--- a/stable_languages/serbian.txt
+++ b/stable_languages/serbian.txt
@@ -2,6 +2,7 @@
 ##ownname Srpski
 ##isocode sr_RS
 ##plural 6
+##textdir ltr
 ##grflangid 0x0d
 ##gender muški ženski srednji
 ##case nom big gen dat aku vok lok ins

--- a/stable_languages/simplified_chinese.txt
+++ b/stable_languages/simplified_chinese.txt
@@ -2,4 +2,5 @@
 ##ownname 简体中文
 ##isocode zh_CN
 ##plural 1
+##textdir ltr
 ##grflangid 0x56

--- a/stable_languages/slovak.txt
+++ b/stable_languages/slovak.txt
@@ -2,6 +2,7 @@
 ##ownname Slovenčina
 ##isocode sk_SK
 ##plural 10
+##textdir ltr
 ##grflangid 0x16
 ##gender m z s
 ##case g

--- a/stable_languages/slovenian.txt
+++ b/stable_languages/slovenian.txt
@@ -2,5 +2,6 @@
 ##ownname Slovenščina
 ##isocode sl_SI
 ##plural 8
+##textdir ltr
 ##grflangid 0x2c
 ##case r d t

--- a/stable_languages/spanish.txt
+++ b/stable_languages/spanish.txt
@@ -2,5 +2,6 @@
 ##ownname Español (ES)
 ##isocode es_ES
 ##plural 0
+##textdir ltr
 ##grflangid 0x04
 ##gender m f

--- a/stable_languages/spanish_MX.txt
+++ b/stable_languages/spanish_MX.txt
@@ -2,5 +2,6 @@
 ##ownname Español (MX)
 ##isocode es_MX
 ##plural 0
+##textdir ltr
 ##grflangid 0x55
 ##gender m f

--- a/stable_languages/swedish.txt
+++ b/stable_languages/swedish.txt
@@ -2,4 +2,5 @@
 ##ownname Svenska
 ##isocode sv_SE
 ##plural 0
+##textdir ltr
 ##grflangid 0x2e

--- a/stable_languages/tamil.txt
+++ b/stable_languages/tamil.txt
@@ -2,4 +2,5 @@
 ##ownname தமிழ்
 ##isocode ta_IN
 ##plural 0
+##textdir ltr
 ##grflangid 0x0a

--- a/stable_languages/thai.txt
+++ b/stable_languages/thai.txt
@@ -2,4 +2,5 @@
 ##ownname Thai
 ##isocode th_TH
 ##plural 1
+##textdir ltr
 ##grflangid 0x42

--- a/stable_languages/traditional_chinese.txt
+++ b/stable_languages/traditional_chinese.txt
@@ -2,4 +2,5 @@
 ##ownname 繁體中文
 ##isocode zh_TW
 ##plural 1
+##textdir ltr
 ##grflangid 0x0c

--- a/stable_languages/turkish.txt
+++ b/stable_languages/turkish.txt
@@ -2,5 +2,6 @@
 ##ownname Türkçe
 ##isocode tr_TR
 ##plural 1
+##textdir ltr
 ##grflangid 0x3e
 ##case tamlanan

--- a/stable_languages/ukrainian.txt
+++ b/stable_languages/ukrainian.txt
@@ -2,6 +2,7 @@
 ##ownname Українська
 ##isocode uk_UA
 ##plural 6
+##textdir ltr
 ##grflangid 0x33
 ##gender m f s mn
 ##case r d z

--- a/stable_languages/vietnamese.txt
+++ b/stable_languages/vietnamese.txt
@@ -2,4 +2,5 @@
 ##ownname Tiếng Việt
 ##isocode vi_VN
 ##plural 1
+##textdir ltr
 ##grflangid 0x54

--- a/stable_languages/welsh.txt
+++ b/stable_languages/welsh.txt
@@ -2,4 +2,5 @@
 ##ownname Cymraeg
 ##isocode cy_GB
 ##plural 0
+##textdir ltr
 ##grflangid 0x0f

--- a/unstable_languages/chuvash.txt
+++ b/unstable_languages/chuvash.txt
@@ -2,4 +2,5 @@
 ##ownname Чӑвашла
 ##isocode cv_RU
 ##plural 0
+##textdir ltr
 ##grflangid 0x0b

--- a/unstable_languages/frisian.txt
+++ b/unstable_languages/frisian.txt
@@ -2,4 +2,5 @@
 ##ownname Frysk
 ##isocode fy_NL
 ##plural 0
+##textdir ltr
 ##grflangid 0x32

--- a/unstable_languages/ido.txt
+++ b/unstable_languages/ido.txt
@@ -2,4 +2,5 @@
 ##ownname Ido
 ##isocode io_IO
 ##plural 0
+##textdir ltr
 ##grflangid 0x06

--- a/unstable_languages/macedonian.txt
+++ b/unstable_languages/macedonian.txt
@@ -2,4 +2,5 @@
 ##ownname Македонски
 ##isocode mk_MK
 ##plural 0
+##textdir ltr
 ##grflangid 0x26

--- a/unstable_languages/maltese.txt
+++ b/unstable_languages/maltese.txt
@@ -2,4 +2,5 @@
 ##ownname Malti
 ##isocode mt_MT
 ##plural 12
+##textdir ltr
 ##grflangid 0x09

--- a/unstable_languages/marathi.txt
+++ b/unstable_languages/marathi.txt
@@ -2,4 +2,5 @@
 ##ownname मराठी
 ##isocode mr_IN
 ##plural 0
+##textdir ltr
 ##grflangid 0x11

--- a/unstable_languages/persian.txt
+++ b/unstable_languages/persian.txt
@@ -2,4 +2,5 @@
 ##ownname فارسی
 ##isocode fa_IR
 ##plural 0
+##textdir rtl
 ##grflangid 0x62

--- a/unstable_languages/urdu.txt
+++ b/unstable_languages/urdu.txt
@@ -2,5 +2,6 @@
 ##ownname Urdu
 ##isocode ur_PK
 ##plural 0
+##textdir rtl
 ##grflangid 0x5c
 ##gender m f

--- a/views/string_form.tpl
+++ b/views/string_form.tpl
@@ -69,7 +69,7 @@
             <div class="control-group {{('error','')[len(tc.transl[0].errors) == 0]}}">
                 <label class="control-label">Translation:</label>
                 <div class="controls">
-                    <textarea class="span8" name="text_{{tc.case}}" id="text_{{tc.case}}" rows="4"
+                    <textarea class="span8" name="text_{{tc.case}}" id="text_{{tc.case}}" rows="4" dir="{{lng.info.textdir}}"
                     % if len(tc.case) == 0:
                         oninput="updatePlaceholder()"
                     % end
@@ -126,7 +126,7 @@
                                 <tr>
                                     <td>{{tl.user}}</td>
                                     <td>{{tl.stamp_desc}} ago</td>
-                                    <td>{{tl.text.text}}</td>
+                                    <td dir="{{lng.info.textdir}}">{{tl.text.text}}</td>
                                 </tr>
                             % end
                         </tbody>
@@ -170,7 +170,7 @@
                     <dl class="dl-horizontal">
                         % for rel in tc.related:
                             <dt style="width: 23em; text-align: left"><a href="/string/{{pmd.name}}/{{lng.name}}/{{rel.sname}}" title="{{rel.sname}}">{{rel.sname}}</a></dt>
-                            <dd style="margin-left: 25em">{{rel.text.text}}<p></p></dd>
+                            <dd style="margin-left: 25em" dir="{{lng.info.textdir}}">{{rel.text.text}}<p></p></dd>
                         % end
                     </dl>
             % end

--- a/views/translation.tpl
+++ b/views/translation.tpl
@@ -35,7 +35,7 @@
                 <li><a href="/string/{{pmd.name}}/{{lng.name}}/{{sdd.sname}}">{{sdd.sname}}</a></li>
             % end
             % for cdd in sdd.cases:
-                <dd>({{cdd.state}}) <strong>{{cdd.get_str_casename(sdd.sname)}}</strong> :{{cdd.text}}</dd>
+                <dd>({{cdd.state}}) <strong>{{cdd.get_str_casename(sdd.sname)}}</strong> :<span dir="{{lng.info.textdir}}">{{cdd.text}}</span></dd>
             % end
             </dl>
         % end

--- a/webtranslate/newgrf/language_info.py
+++ b/webtranslate/newgrf/language_info.py
@@ -70,6 +70,9 @@ class LanguageData:
     @ivar plural: Plural form number.
     @type plural: C{int}
 
+    @ivar textdir: Text direction: "ltr" or "rtl"
+    @type textdir: C{str}
+
     @ivar grflangid: Language id according to the NewGRF system.
     @type grflangid: C{int}
 
@@ -89,6 +92,7 @@ class LanguageData:
         self.ownname = found_lines["ownname"]
         self.isocode = found_lines["isocode"]
         self.plural = found_lines["plural"]
+        self.textdir = found_lines["textdir"]
         self.grflangid = found_lines["grflangid"]
 
         gender = found_lines.get("gender")
@@ -127,6 +131,7 @@ recognized = [
     LanguageLine("ownname", re.compile("##ownname +(.*) *$"), as_str, True),
     LanguageLine("isocode", re.compile("##isocode +([a-z][a-z]_[A-Z][A-Z]) *$"), as_str, True),
     LanguageLine("plural", re.compile("##plural +((0[xX])?[0-9A-Fa-f]+) *$"), as_int, True),
+    LanguageLine("textdir", re.compile("##textdir +(ltr|rtl) *$"), as_str, True),
     LanguageLine("grflangid", re.compile("##grflangid +((0[xX])?[0-9A-Fa-f]+) *$"), as_int, True),
     LanguageLine("gender", re.compile("##gender +(.*) *$"), as_strlist, False),
     LanguageLine("case", re.compile("##case +(.*) *$"), as_strlist, False),


### PR DESCRIPTION
See #36 