### PR TITLE
Improve error checking when uploading translations

### DIFF
--- a/scripts/lang_sync
+++ b/scripts/lang_sync
@@ -366,7 +366,7 @@ def post_form_upload(url, form_data, form_fentry, form_fname, fdata):
 
     # Perform the request, and return the read data.
     with urllib.request.urlopen(req) as resp:
-        if resp.status != 200:
+        if resp.status != 200 or resp.geturl().find("Successfully") < 0:
             return False
 
         resp.read()

--- a/webtranslate/newgrf/language_file.py
+++ b/webtranslate/newgrf/language_file.py
@@ -992,18 +992,15 @@ string_pat = re.compile("^([A-Za-z_0-9]+)(\\.[A-Za-z0-9]+)?[ \\t]*:(.*)$")
 bom = codecs.BOM_UTF8.decode("utf-8")
 
 
-def load_language_file(projtype, handle, max_size, lng_data=None):
+def load_language_file(projtype, text, lng_data=None):
     """
     Load a language file.
 
     @param projtype: Project type.
     @type  projtype: L{ProjectType}
 
-    @param handle: File handle.
-    @type  handle: L{io.BufferedReader}
-
-    @param max_size: Maimum allowed size to read from the handle.
-    @type  max_size: C{int}
+    @param text: Language file content.
+    @type  text: C{str}
 
     @param lng_data: Suggested language, if specified.
     @type  lng_data: L{LanguageData} or C{None}
@@ -1019,11 +1016,6 @@ def load_language_file(projtype, handle, max_size, lng_data=None):
         # If the project has no ##grflangid support, and there is lng_data provided, use it.
         data.set_lang(lng_data)
 
-    # Read file, and process the lines.
-    text = handle.read(max_size)
-    if len(text) == max_size:
-        data.add_error(ERROR, None, "File not completely read")
-    text = str(text, encoding="utf-8")
     for lnum, line in enumerate(text.split("\n")):
         line = line.rstrip()
         if line.startswith(bom):

--- a/webtranslate/pages/upload_language.py
+++ b/webtranslate/pages/upload_language.py
@@ -131,8 +131,20 @@ def handle_upload(userauth, pmd, projname, langfile, override, is_base, lng_data
         abort(404, "Project has no base language")
         return None
 
+    # Read upload data
+    text = langfile.file.read(config.cfg.language_file_size)
+    if len(text) == config.cfg.language_file_size:
+        abort(400, "Language file too large.")
+        return None
+
+    try:
+        text = str(text, encoding="utf-8")
+    except UnicodeDecodeError:
+        abort(400, "Language file must be utf-8 encoded.")
+        return None
+
     # Parse language file, and report any errors.
-    ng_data = language_file.load_language_file(pdata.projtype, langfile.file, config.cfg.language_file_size, lng_data)
+    ng_data = language_file.load_language_file(pdata.projtype, text, lng_data)
     if len(ng_data.errors) > 0:
         return template("upload_errors", userauth=userauth, pmd=pmd, errors=ng_data.errors)
 


### PR DESCRIPTION
Fixes
* When uploading files that exceeded the upload size limit, eints would truncate them, and try to process the rest anyway. (very weird)
* Truncation could result in invalid utf-8 sequences, resulting in status 500.
* The upload script considered uploads successful, when eints redirected to a user-friendly pages listing the problems.