### PR TITLE
Fix #49: include EINTS manual in the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,21 @@
+FROM python:3.8-slim as builder
+
+WORKDIR /docs
+
+COPY docs /docs
+
+RUN pip --no-cache-dir install -U pip \
+    && pip --no-cache-dir install sphinx
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    \
+    make \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN make -C /docs
+
+
+
 FROM python:3.8-slim
 
 ARG BUILD_DATE=""
@@ -37,6 +55,8 @@ COPY stable_languages /code/stable_languages
 RUN mkdir -p /code/unstable_languages
 COPY views /code/views
 COPY webtranslate /code/webtranslate
+
+COPY --from=builder /docs/manual/_build/html /code/static/docs
 
 VOLUME ["/data"]
 ENTRYPOINT ["python", "-m", "webtranslate", "--project-root", "/data", "--server-host", "0.0.0.0"]

--- a/docs/manual/string_commands.rst
+++ b/docs/manual/string_commands.rst
@@ -19,38 +19,40 @@ based on project type and command type.
 Non-positional NewGrf string commands
 =====================================
 
-=============== ===========================================================
-Command         Effect
-=============== ===========================================================
-``{}``          Continue at the next line
-``{{}``         Output a ``{``
-``{NBSP}``      Display a non-breaking space
-``{COPYRIGHT}`` Display a copyright symbol
-``{TRAIN}``     Display a train symbol
-``{LORRY}``     Display a truck symbol
-``{BUS}``       Display a bus symbol
-``{PLANE}``     Display a plane symbol
-``{SHIP}``      Display a ship symbol
-``{TINYFONT}``  Switch to a small font
-``{BIGFONT}``   Switch to a big font
-``{BLUE}``      Output following text in blue colour
-``{SILVER}``    Output following text in silver colour
-``{GOLD}``      Output following text in gold colour
-``{RED}``       Output following text in red colour
-``{PURPLE}``    Output following text in purple colour
-``{LTBROWN}``   Output following text in light brown colour
-``{ORANGE}``    Output following text in orange colour
-``{GREEN}``     Output following text in green colour
-``{YELLOW}``    Output following text in yellow colour
-``{DKGREEN}``   Output following text in dark green colour
-``{CREAM}``     Output following text in cream colour
-``{BROWN}``     Output following text in brown colour
-``{WHITE}``     Output following text in white colour
-``{LTBLUE}``    Output following text in light blue colour
-``{GRAY}``      Output following text in gray colour
-``{DKBLUE}``    Output following text in dark blue colour
-``{BLACK}``     Output following text in black colour
-=============== ===========================================================
+================= ===========================================================
+Command           Effect
+================= ===========================================================
+``{}``            Continue at the next line
+``{{}``           Output a ``{``
+``{NBSP}``        Display a non-breaking space
+``{COPYRIGHT}``   Display a copyright symbol
+``{TRAIN}``       Display a train symbol
+``{LORRY}``       Display a truck symbol
+``{BUS}``         Display a bus symbol
+``{PLANE}``       Display a plane symbol
+``{SHIP}``        Display a ship symbol
+``{TINYFONT}``    Switch to a small font
+``{BIGFONT}``     Switch to a big font
+``{BLUE}``        Output following text in blue colour
+``{SILVER}``      Output following text in silver colour
+``{GOLD}``        Output following text in gold colour
+``{RED}``         Output following text in red colour
+``{PURPLE}``      Output following text in purple colour
+``{LTBROWN}``     Output following text in light brown colour
+``{ORANGE}``      Output following text in orange colour
+``{GREEN}``       Output following text in green colour
+``{YELLOW}``      Output following text in yellow colour
+``{DKGREEN}``     Output following text in dark green colour
+``{CREAM}``       Output following text in cream colour
+``{BROWN}``       Output following text in brown colour
+``{WHITE}``       Output following text in white colour
+``{LTBLUE}``      Output following text in light blue colour
+``{GRAY}``        Output following text in gray colour
+``{DKBLUE}``      Output following text in dark blue colour
+``{BLACK}``       Output following text in black colour
+``{PUSH_COLOUR}`` Store the current colour
+``{POP_COLOUR}``  Restore last saved colour
+================= ===========================================================
 
 .. _pos-newgrf-string_commands:
 
@@ -106,8 +108,10 @@ Command                 Effect
 ``{BUS}``               Output a bus symbol
 ``{PLANE}``             Output an aircraft
 ``{SHIP}``              Output a ship symbol
+``{NORMAL_FONT}``       Switch to a normal font
 ``{TINY_FONT}``         Switch to a small font
 ``{BIG_FONT}``          Switch to a big font
+``{MONO_FONT}``         Switch to a mono font
 ``{BLUE}``              Output following text in blue colour
 ``{SILVER}``            Output following text in silver colour
 ``{GOLD}``              Output following text in gold colour
@@ -125,6 +129,8 @@ Command                 Effect
 ``{GRAY}``              Output following text in gray colour
 ``{DKBLUE}``            Output following text in dark blue colour
 ``{BLACK}``             Output following text in black colour
+``{PUSH_COLOUR}``       Store the current colour
+``{POP_COLOUR}``        Restore last saved colour
 ``{LRM}``               Left-to-right mark, zero-width character
 ``{RLM}``               Right-to-left mark, zero-width non-Arabic character
 ``{LRE}``               Treat the following text as embedded left-to-right

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,10 @@
 certifi==2021.5.30
-chardet==4.0.0
-charset-normalizer==2.0.4
+charset-normalizer==2.0.6
 click==8.0.1
 idna==3.2
 oauthlib==3.1.1
 openttd-helpers==1.0.1
 requests==2.26.0
 requests-oauthlib==1.3.0
-sentry-sdk==1.3.1
-urllib3==1.26.6
+sentry-sdk==1.4.3
+urllib3==1.26.7

--- a/views/main_template.tpl
+++ b/views/main_template.tpl
@@ -27,7 +27,7 @@
                     <li><a href="/newproject"><i class="icon-plus-sign"></i> New Project</a></li>
                 </ul>
                 <ul class="nav pull-right">
-                    <li><a target="_blank" href="http://bundles.openttdcoop.org/eints/nightlies/LATEST/docs/usage.html"><i class="icon-book"></i> Manual</a></li>
+                    <li><a target="_blank" href="/static/docs/usage.html"><i class="icon-book"></i> Manual</a></li>
                     %if userauth.is_auth:
                         <li><a href="/userprofile"><i class="icon-user"></i> Profile ({{ userauth.name }})</a></li>
                         <li><a href="/logout"><i class="icon-user"></i> Logout</a></li>

--- a/views/root.tpl
+++ b/views/root.tpl
@@ -5,5 +5,5 @@
     <li><a href="languages">List of languages</a></li>
     <li><a href="projects">List of projects</a></li>
     <li><a href="newproject">Start a new project</a></li>
-    <li><a target="_blank" href="http://bundles.openttdcoop.org/eints/nightlies/LATEST/docs/usage.html">Read the manual</a></li>
+    <li><a target="_blank" href="/static/docs/usage.html">Read the manual</a></li>
 </ul>

--- a/views/string_form.tpl
+++ b/views/string_form.tpl
@@ -3,7 +3,7 @@
 <h1>
     <a class="eint-header-link" href="/project/{{pmd.name}}">{{pmd.human_name}}</a>
 </h1>
-<a class="pull-right" target="_blank" href="http://bundles.openttdcoop.org/eints/nightlies/LATEST/docs/strings.html">String editing Manual</a>
+<a class="pull-right" target="_blank" href="/static/docs/strings.html">String editing Manual</a>
 <hr />
 <div class="clearfix">
     <h2 class="eint-heading-icon eint-icon-document-1-edit">


### PR DESCRIPTION
Links to documentation points to openttdcoop.org (and it's currently down).
As the documentation is generated from eints repo, I think it's a good idea to include it in the image and stop relying on an external location.