### PR TITLE
Change: enable language creation for all projects, but steam-data.

### DIFF
--- a/rights_example.dat
+++ b/rights_example.dat
@@ -34,8 +34,13 @@ OWNER + /makeproject/*/-/add
 OWNER      + /string/*/*/*
 TRANSLATOR + /string/*/*/*
 
-# Language file uploading, language deletion and creation
+# Language creation is allowed for all projects, but steam-data
+OWNER      + /makelanguage/steam-data/*/*
+*          - /makelanguage/steam-data/*/*
+OWNER      + /makelanguage/*/*/*
+TRANSLATOR + /makelanguage/*/*/*
+
+# Language file uploading, language deletion
 OWNER + /upload/*/-/*
 OWNER + /delete/*/*/*
-OWNER + /makelanguage/*/*/*
 OWNER + /projsettings/*/-/*


### PR DESCRIPTION
This is a backport from the openttd-github branch.

This file is actually copied in `Dockerfile`, so it changes how we deploy eints. But it is also a fine example for other people to understand how eints could work.