### PR TITLE
Change: List languages with name instead of ISO code in the commit messages.

### DIFF
--- a/scripts/lang_sync
+++ b/scripts/lang_sync
@@ -388,8 +388,9 @@ class EintsLanguageInfo:
     @type last_change: C{None} or C{str}
     """
 
-    def __init__(self, isocode, parent_lang, last_change):
+    def __init__(self, isocode, name, parent_lang, last_change):
         self.isocode = isocode
+        self.name = name
         self.parent_lang = parent_lang
         self.last_change = last_change
 
@@ -422,6 +423,7 @@ def get_eints_languages():
         isocode = line.get("isocode")
         if isocode is None or len(isocode) == 0:
             continue
+        name = line.get("name", isocode)
 
         plang = line.get("base_isocode")
         if plang is None:
@@ -432,7 +434,7 @@ def get_eints_languages():
         # last_change = line.get("changetime")
         # XXX Parse and validate the last change date
 
-        el = EintsLanguageInfo(isocode, plang, None)
+        el = EintsLanguageInfo(isocode, name, plang, None)
         result.append(el)
 
     eints_files_cache = result
@@ -1030,7 +1032,7 @@ def perform_download(ll_files, el_files, credits_handle, path_base):
             if credits_handle is not None:
                 credits = collect_credits(current_strings, parsed)
                 if len(credits) > 0:
-                    credits_handle.write(el.isocode + ": " + credits + "\n")
+                    credits_handle.write(el.name.lower() + ": " + credits + "\n")
                     credits_handle.flush()  # Flush it to disk, so it is preserved on crash.
             write_parsed_lines(parsed, path, eolstyle)
 

--- a/webtranslate/pages/download_list.py
+++ b/webtranslate/pages/download_list.py
@@ -47,7 +47,7 @@ def download_list(userauth, prjname):
 
     pdata = pmd.pdata
     response.content_type = "text/plain; charset=UTF-8"
-    lines = ["isocode,base_isocode,changetime"]
+    lines = ["isocode,name,base_isocode,changetime"]
     for lng, ldata in pdata.languages.items():
         tstamp = get_newest_change(ldata)
         if tstamp is None:
@@ -60,7 +60,7 @@ def download_list(userauth, prjname):
         else:
             parent_lng = pdata.base_language
 
-        line = "{},{},{}".format(ldata.name, parent_lng, text)
+        line = "{},{},{},{}".format(ldata.name, ldata.info.name, parent_lng, text)
         lines.append(line)
 
     return "\n".join(lines) + "\n"


### PR DESCRIPTION
This is a backport from the openttd-github branch.