### PR TITLE
Remove: admin links from public pages

### DIFF
--- a/views/main_template.tpl
+++ b/views/main_template.tpl
@@ -24,7 +24,6 @@
                     <li><a href="/"><i class="icon-home"></i> Home</a></li>
                     <li><a href="/languages"><i class="icon-list-alt"></i> Languages</a></li>
                     <li><a href="/projects"><i class="icon-list-alt"></i> Projects</a></li>
-                    <li><a href="/newproject"><i class="icon-plus-sign"></i> New Project</a></li>
                 </ul>
                 <ul class="nav pull-right">
                     <li><a target="_blank" href="/static/docs/usage.html"><i class="icon-book"></i> Manual</a></li>

--- a/views/project.tpl
+++ b/views/project.tpl
@@ -20,11 +20,11 @@
         <thead>
             <tr>
                 <th colspan="3">Languages ({{len(pmd.pdata.languages)}})</th>
-                <th colspan="3" style="text-align:center;"><i class="icon-cog"></i> Actions</th>
+                <th colspan="2" style="text-align:center;"><i class="icon-cog"></i> Actions</th>
                 <th colspan="{{len(data.STATE_DISPLAY)}}" style="text-align:center;">Strings ({{len(base_lng.changes)}})</th>
             </tr>
             <tr>
-                <th colspan="6"></th>
+                <th colspan="5"></th>
                 % for s in reversed(data.STATE_DISPLAY):
                     <th class="number">{{s.name}}</th>
                 % end
@@ -36,7 +36,6 @@
                 <td><strong><a href="/translation/{{pmd.name}}/{{base_lng.name}}">{{base_lng.name}}</a></strong></td>
                 <td><strong><a href="/translation/{{pmd.name}}/{{base_lng.name}}">{{base_lng.info.name}}</a></strong></td>
                 <td><strong>(Base Language)</strong></td>
-                <td>-</td>
                 <td><a class="pull-right" href="/download/{{pmd.name}}/{{base_lng.name}}"><i class="icon-download"></i> Download</a></td>
                 % for s in reversed(data.STATE_DISPLAY):
                     % if s.baselng:
@@ -48,7 +47,7 @@
             </tr>
         % if len(transl) == 0:
             <tr>
-                <td colspan="{{6 + len(data.STATE_DISPLAY)}}" class="alert alert-info">To get started with translation, upload a language file</td>
+                <td colspan="{{5 + len(data.STATE_DISPLAY)}}" class="alert alert-info">To get started with translation, upload a language file</td>
             </tr>
         % else:
             % for lng, counts in transl:
@@ -67,7 +66,6 @@
                     % else:
                         <td>Done!</td>
                     % end
-                    <td><a class="pull-right" href="/delete/{{pmd.name}}/{{lng.name}}"><i class="icon-remove-circle"></i> Delete</a></td>
                     <td><a class="pull-right" href="/download/{{pmd.name}}/{{lng.name}}"><i class="icon-download"></i> Download</a></td>
                     % for s in reversed(data.STATE_DISPLAY):
                         <td class="number">{{counts[s.code]}}</td>

--- a/views/root.tpl
+++ b/views/root.tpl
@@ -4,6 +4,5 @@
 <ul>
     <li><a href="languages">List of languages</a></li>
     <li><a href="projects">List of projects</a></li>
-    <li><a href="newproject">Start a new project</a></li>
     <li><a target="_blank" href="/static/docs/usage.html">Read the manual</a></li>
 </ul>


### PR DESCRIPTION
If you are admin, you know those links. They are not useful for anyone else.
Owh, and please don't run eints where you are allowed to just create
projects and languages, that is not secure.