### PR TITLE
Feature: the string translation history shows exact time-stamps, and which version is committed or pending.

### DIFF
--- a/views/string_form.tpl
+++ b/views/string_form.tpl
@@ -104,7 +104,10 @@
                     <div class="controls">
                         <span class="help-block">Translation created by "{{tc.transl[0].user}}"
                             % if tc.transl[0].stamp_desc is not None:
-                                ({{tc.transl[0].stamp_desc}} ago)
+                                (<span title="{{tc.transl[0].stamp}}">{{tc.transl[0].stamp_desc}} ago</span>)
+                            % end
+                            % if not tc.transl[0].last_upload:
+                                (commit pending)
                             % end
                         </span>
                     </div>
@@ -125,7 +128,12 @@
                             % for tl in tc.transl[1:]:
                                 <tr>
                                     <td>{{tl.user}}</td>
-                                    <td>{{tl.stamp_desc}} ago</td>
+                                    <td>
+                                        <span title="{{tl.stamp}}">{{tl.stamp_desc}} ago</span>
+                                        % if tl.last_upload:
+                                            (committed)
+                                        % end
+                                    </td>
                                     <td dir="{{lng.info.textdir}}">{{tl.text.text}}</td>
                                 </tr>
                             % end

--- a/webtranslate/pages/string_edit.py
+++ b/webtranslate/pages/string_edit.py
@@ -86,6 +86,7 @@ class Translation:
             self.user = user
             self.trans_base = lchg.base_text
             self.text = lchg.new_text
+            self.last_upload = lchg.last_upload
             if saved:
                 self.stamp_desc = utils.get_relative_time(lchg.stamp, now)
                 self.stamp = str(lchg.stamp)
@@ -97,6 +98,7 @@ class Translation:
             self.trans_base = self.current_base
             txt = data.Text("", "", None)  # This breaks assumptions on the Text class.
             self.text = txt
+            self.last_upload = False
             self.stamp_desc = None
             self.stamp = None
 


### PR DESCRIPTION
Mainly a debugging feature, but also nice-to-know for the translator.