### PR TITLE
Fix #70: commited translations were not tagged as "committed".

### DIFF
--- a/webtranslate/pages/upload_language.py
+++ b/webtranslate/pages/upload_language.py
@@ -242,14 +242,16 @@ def handle_upload(userauth, pmd, projname, langfile, override, is_base, lng_data
                 if chgs is None:
                     lng.changes[sv.name] = [chg]
                 else:
-                    for c in chgs:
-                        c.last_upload = False
                     chgs.append(chg)
             elif override:  # Override existing entry.
                 chg.stamp = stamp
                 chg.user = userauth.name
-                for c in chgs:
-                    c.last_upload = c == chg
+
+            # Set the change as the "last uploaded" one
+            for c in chgs:
+                c.last_upload = False
+
+            chg.last_upload = True
 
         # Update language properties as well.
         copy_lng_properties(pdata.projtype, ng_data, lng)


### PR DESCRIPTION
```
When syncing translations from git to eints, strings were only tagged as
"committed" if they were unknown to eints, so new translations from eints
were never tagged after the commit.

When translators then updated the translation again, eints would discard
old untagged translation eventually. At that point the next git sync
would consider the old translation in git as newer than the fresh
translation, and essentially revert the translator's work.
```