### PR TITLE
Deeplink to language inside project

### DIFF
--- a/views/language.tpl
+++ b/views/language.tpl
@@ -18,7 +18,7 @@
         <tbody>
         % for pmd, exists, lstate in prjdata:
             <tr>
-            <td><a href="/project/{{pmd.name}}">{{pmd.human_name}}</a></td>
+            <td><a href="/translation/{{pmd.name}}/{{lnginfo.isocode}}">{{pmd.human_name}}</a></td>
             % if exists:
                 % if utils.lang_needs_fixing(lstate):
                   <td><a href="/fix/{{pmd.name}}/{{lnginfo.isocode}}">Start fixing</a></td>


### PR DESCRIPTION
The UI's menu prominently lists "Languages" as a top-level menu item. Clicking a language from that page it shows the projects for that language. Then after clicking a project, I would expect to arrive at the overview page of that language for that project, however that currently navigates to the project page and I have (yet again) select the language I want to translate.

This PR changes that by eliminating this last step.

I haven't verified whether this change actually works, as I don't have a local checkout / working environment. Based on the template variables it seems fine to me, but needs an additional pair of eyes.