### PR TITLE
Fix #115: add support for {POWER_TO_WEIGHT} introduced by OpenTTD#10123

### DIFF
--- a/.github/workflows/commit-checker.yml
+++ b/.github/workflows/commit-checker.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 4
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,27 +14,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up Python 3.8
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
     - name: Install dependencies
       run: python -m pip install -r requirements.txt
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: python
         queries: security-and-quality
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2
 
   docker:
     name: Docker build
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Build
       run: docker build .
 
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Flake8
       uses: TrueBrain/actions-flake8@v2
       with:
@@ -54,9 +54,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up Python 3.8
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
     - name: Black
@@ -80,4 +80,4 @@ jobs:
 
     steps:
     - name: Check annotations
-      uses: OpenTTD/actions/annotation-check@v2
+      uses: OpenTTD/actions/annotation-check@v3

--- a/docs/manual/string_commands.rst
+++ b/docs/manual/string_commands.rst
@@ -165,6 +165,7 @@ Command                Plural Effect
 ``{CARGO_TINY}``          no  Tiny cargo description with only the amount.
 ``{CARGO_LIST}``          no
 ``{POWER}``               no
+``{POWER_TO_WEIGHT}``     no
 ``{VOLUME_LONG}``         no
 ``{VOLUME_SHORT}``        no
 ``{WEIGHT_LONG}``         no

--- a/webtranslate/parameter_info_table.py
+++ b/webtranslate/parameter_info_table.py
@@ -107,6 +107,7 @@ _GS_PARAMETERS = [
     ParameterInfo("CARGO_TINY",        [P__, PP_], 1,    False, True ),  # tiny cargo description with only the amount
     ParameterInfo("CARGO_LIST",        [P__],      None, True,  True ),
     ParameterInfo("POWER",             [PP_],      0,    False, True ),
+    ParameterInfo("POWER_TO_WEIGHT",   [PP_],      0,    False, True ),
     ParameterInfo("VOLUME_LONG",       [PP_],      0,    False, True ),
     ParameterInfo("VOLUME_SHORT",      [PP_],      0,    False, True ),
     ParameterInfo("WEIGHT_LONG",       [PP_],      0,    False, True ),


### PR DESCRIPTION
[OpenTTD#10123](https://github.com/OpenTTD/OpenTTD/pull/10123) introduced `{POWER_TO_WEIGHT}` and strings using it are currently considered invalid.

Edit: workflows needed an update but I think I'll let @TrueBrain handle `deployment.yml` and `publish.yml`