### PR TITLE
Add: allow defining the URL to use for GitHub for user authentication

### DIFF
--- a/webtranslate/__main__.py
+++ b/webtranslate/__main__.py
@@ -62,6 +62,20 @@ log = logging.getLogger(__name__)
 @click.option("--github-oauth2-client-id", help="Client ID for the GitHub OAuth2 Application.")
 @click.option("--github-oauth2-client-secret", help="Client Secret for the GitHub OAuth2 Application.")
 @click.option("--translators-password", help="Password for the translators account.")
+@click.option(
+    "--github-api-url",
+    help="GitHub API URL to use.",
+    default="https://api.github.com",
+    show_default=True,
+    metavar="URL",
+)
+@click.option(
+    "--github-url",
+    help="GitHub URL to use.",
+    default="https://github.com",
+    show_default=True,
+    metavar="URL",
+)
 def run(
     server_mode,
     server_host,
@@ -84,6 +98,8 @@ def run(
     github_oauth2_client_id,
     github_oauth2_client_secret,
     translators_password,
+    github_api_url,
+    github_url,
 ):
     """
     Run the program (it was started from the command line).
@@ -117,6 +133,8 @@ def run(
             fp.write(f"    <oauth2-client-id>{github_oauth2_client_id}</oauth2-client-id>\n")
             fp.write(f"    <oauth2-client-secret>{github_oauth2_client_secret}</oauth2-client-secret>\n")
             fp.write(f"    <translators-password>{translators_password or ''}</translators-password>\n")
+            fp.write(f"    <github-api-url>{github_api_url}</github-api-url>\n")
+            fp.write(f"    <github-url>{github_url}</github-url>\n")
             fp.write("  </github>\n")
 
         fp.write("</config>\n")

--- a/webtranslate/config.py
+++ b/webtranslate/config.py
@@ -294,6 +294,8 @@ class Config:
             github.github_oauth_client_id = get_subnode_text(gh_node, "oauth2-client-id")
             github.github_oauth_client_secret = get_subnode_text(gh_node, "oauth2-client-secret")
             protect.translators_password = get_subnode_text(gh_node, "translators-password")
+            github.github_api_url = get_subnode_text(gh_node, "github-api-url")
+            github.github_url = get_subnode_text(gh_node, "github-url")
 
         # Ldap configuration
         ldap_node = loader.get_single_child_node(cfg, "ldap", True)

--- a/webtranslate/users/github.py
+++ b/webtranslate/users/github.py
@@ -20,6 +20,8 @@ github_organization = None
 github_org_api_token = None
 github_oauth_client_id = None
 github_oauth_client_secret = None
+github_api_url = None
+github_url = None
 
 
 def request_teams(name):
@@ -51,7 +53,7 @@ def request_teams(name):
 
         variables = {"org": github_organization, "user": name}
         r = requests.post(
-            "https://api.github.com/graphql",
+            f"{github_api_url}/graphql",
             headers={"Authorization": "bearer " + github_org_api_token},
             json={"query": query, "variables": variables},
         )
@@ -96,12 +98,12 @@ class GithubUserAuthentication(userauth.UserAuthentication):
             self.state = None  # single use, forget now
 
             oauth.fetch_token(
-                "https://github.com/login/oauth/access_token",
+                f"{github_url}/login/oauth/access_token",
                 client_secret=github_oauth_client_secret,
                 authorization_response=request_url,
             )
             if oauth.authorized:
-                info = oauth.get("https://api.github.com/user").json()
+                info = oauth.get(f"{github_api_url}/user").json()
 
                 self.name = info["login"]  # can be changed, and reassigned to someone else
                 self.userid = int(info["id"])  # persistent


### PR DESCRIPTION
As GitHub is IPv4-only, sometimes there is a need to proxy GitHub via other domains to enable IPv6 connectivity. For those cases, these settings are useful.