### PR TITLE
Fix: Upload language page raised 500 error due to syntax error

### DIFF
--- a/webtranslate/pages/upload_language.py
+++ b/webtranslate/pages/upload_language.py
@@ -38,7 +38,7 @@ def page_get(userauth, prjname):
             "upload_lang_select",
             userauth=userauth,
             pmd=pmd,
-            lnginfos=sorted(pdata.get_all_languages(), lambda lang: lang.isocode),
+            lnginfos=sorted(pdata.get_all_languages(), key=lambda lang: lang.isocode),
         )
 
 


### PR DESCRIPTION
Python 3 requires a `key=` parameter for `sorted()`. Been broken for a while...