### PR TITLE
Add: Support for SPACE from OpenTTD#13149

### DIFF
--- a/docs/manual/string_commands.rst
+++ b/docs/manual/string_commands.rst
@@ -101,6 +101,7 @@ Command                 Effect
 ======================= ============================================================================
 ``{}``                  Continue at the next line
 ``{{}``                 Output a ``{``
+``{SPACE}``             Display a regular space, only used for trailing spaces.
 ``{NBSP}``              Display a non-breaking space
 ``{COPYRIGHT}``         Display a copyright symbol
 ``{TRAIN}``             Output a train symbol

--- a/webtranslate/parameter_info_table.py
+++ b/webtranslate/parameter_info_table.py
@@ -156,6 +156,7 @@ _GS_PARAMETERS = [
     ParameterInfo("BUS",               [], None, False, True ),
     ParameterInfo("PLANE",             [], None, False, True ),
     ParameterInfo("SHIP",              [], None, False, True ),
+    ParameterInfo("SPACE",             [], None, False, False),
     ParameterInfo("NBSP",              [], None, False, False),
     ParameterInfo("COPYRIGHT",         [], None, False, True ),
 


### PR DESCRIPTION
Fixes #200

The `{SPACE}` string code was added to strgen in OpenTTD#13149 to allow trailing spaces to be included in strings.

This is untested, I have no idea what I'm doing...