### PR TITLE
Fix: Case inconsistency in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim as builder
+FROM python:3.8-slim AS builder
 
 WORKDIR /docs
 


### PR DESCRIPTION
Annotation checks failure because `Dockerfile:1 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match`