### PR TITLE
Fix: contributors in commit message should be in the body, not title

### DIFF
--- a/scripts/eintsgit.py
+++ b/scripts/eintsgit.py
@@ -13,7 +13,7 @@ eints_login_file = "user.cfg"
 
 # Commit credentials
 commit_user = "translators <translators@openttd.org>"
-commit_message = "Update: Translations from eints\n"
+commit_message = "Update: Translations from eints\n\n"
 
 # Source structure
 git_remote = "origin"


### PR DESCRIPTION
By missing an extra newline, it meant that all the text was part of the title (just split over multiple lines). By adding an extra newline, it becomes clear to "git" that those lines are actually the body.