### PR TITLE
Upgrade: Bump Python to 3.11

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,4 +14,4 @@ jobs:
     uses: OpenTTD/actions/.github/workflows/rw-entry-testing-docker-py.yml@v5
     with:
       python-path: webtranslate scripts/filter_update_langs scripts/lang_sync scripts/eintsgit.py
-      python-version: 3.8
+      python-version: 3.11

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim AS builder
+FROM python:3.11-slim AS builder
 
 WORKDIR /docs
 
@@ -16,7 +16,7 @@ RUN make -C /docs
 
 
 
-FROM python:3.8-slim
+FROM python:3.11-slim
 
 ARG BUILD_DATE=""
 ARG BUILD_VERSION="dev"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-certifi==2024.6.2
-charset-normalizer==3.3.2
-click==8.1.7
-idna==3.7
+certifi==2025.1.31
+charset-normalizer==3.4.1
+click==8.1.8
+idna==3.10
 oauthlib==3.2.2
 openttd-helpers==1.4.0
 requests==2.32.3
 requests-oauthlib==2.0.0
-sentry-sdk==2.7.1
-urllib3==2.2.2
+sentry-sdk==2.21.0
+urllib3==2.3.0


### PR DESCRIPTION
This includes a dependency-bump, as it might add/remove polyfill libraries